### PR TITLE
templates: asset improvements

### DIFF
--- a/invenio_base/static/js/settings.js
+++ b/invenio_base/static/js/settings.js
@@ -52,7 +52,8 @@ require.config({
     "searchtypeahead-configuration": "js/search/default_typeahead_configuration",
     "jasmine-events": "js/jasmine/events_checker",
     "jasmine-initialization": "js/jasmine/initialization_checker",
-    "select2": "vendor/select2/select2.min",
+    "select2": "vendors/select2/select2",
+    "jsoneditor": "vendors/json-editor/dist/jsoneditor",
     "ckeditor-core": "vendors/ckeditor/ckeditor",
     "ckeditor-jquery": "vendors/ckeditor/adapters/jquery"
   },
@@ -155,6 +156,9 @@ require.config({
     select2: {
       deps: ["jquery"],
       exports: "select2"
+    },
+    jsoneditor: {
+      exports: "JSONEditor"
     },
     "ckeditor-jquery": {
       deps: ["jquery", "ckeditor-core"]

--- a/invenio_base/templates/base/scripts_base.html
+++ b/invenio_base/templates/base/scripts_base.html
@@ -23,6 +23,6 @@
   <!-- {{ bundle.weight }}: {{ bundle.output }} -->
   {%- endif %}
   {%- assets bundle %}
-  <script type="text/javascript" src="{{ EXTRA.static_url_path }}{{ ASSET_URL }}"></script>
+  <script type="text/javascript" src="{{ (EXTRA.get('static_url_path', '') + ASSET_URL) | replace('//', '/') }}"></script>
   {%- endassets %}
 {%- endfor %}

--- a/invenio_base/templates/base/stylesheets_base.html
+++ b/invenio_base/templates/base/stylesheets_base.html
@@ -23,6 +23,6 @@
   <!-- {{ bundle.weight }}: {{ bundle.output }} -->
   {%- endif %}
   {%- assets bundle %}
-  <link rel="{{ EXTRA.rel }}" type="text/css" href="{{ EXTRA.static_url_path }}{{ ASSET_URL }}"/>
+  <link rel="{{ EXTRA.rel }}" type="text/css" href="{{ (EXTRA.get('static_url_path', '') + ASSET_URL) | replace('//', '/') }}"/>
   {%- endassets %}
 {%- endfor %}


### PR DESCRIPTION
* NEW Adds `jsoneditor` dependency to r.js settings.

* BETTER Replaces `select2.min` with `select2` to simplify debugging.

* FIX Fixes a bug which, under certain conditions, led to wrong asset
  links when working with ASSET_DEBUG=True.

Co-authored-by: Tibor Simko <tibor.simko@cern.ch>

(extracted from https://github.com/inveniosoftware/invenio/pull/3380)