### PR TITLE
base: move base.rst from invenio to invenio-base

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,3 +37,26 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+API
+===
+
+.. automodule:: invenio_base
+   :members:
+
+Wrappers
+--------
+
+.. automodule:: invenio_base.wrappers
+   :members:
+
+Factory
+-------
+
+.. automodule:: invenio_base.factory
+   :members:
+
+Bundles
+-------
+
+.. automodule:: invenio_base.bundles
+   :members:


### PR DESCRIPTION
* BETTER Moves invenio-base's doc base.rst from invenio/docs/base.rst
  to invenio-base/docs/base.rst.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>