### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel coveralls"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -61,6 +61,7 @@ before_script:
   - "inveniomanage database create --quiet"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_base --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_base --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,12 @@ requirements = [
 
 test_requirements = [
     'Flask-Testing>=0.4.1',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
     'httpretty>=0.8.10',
     'mock>=1.0.0',
-    'pytest-cov>=1.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.7.0',
+    'pytest>=2.8.0',
     'unittest2>=0.5',
 ]
 
@@ -80,9 +80,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 


### PR DESCRIPTION
* FIX pytest 2.8.0 removed functionality used for tests. This removes
  calls to the removed functions.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>