### PR TITLE
travis: removal of unnecessary packages

### DIFF
--- a/invenio_base/config.py
+++ b/invenio_base/config.py
@@ -70,26 +70,6 @@ EXTENSIONS = [
 ]
 
 PACKAGES = [
-    'invenio_records',
-    'invenio_search',
-    'invenio_comments',
-    'invenio_collections',
-    'invenio_documents',
-    'invenio_pidstore',
-    'invenio_formatter',
-    'invenio_unapi',
-    'invenio_webhooks',
-    'invenio_deposit',
-    'invenio_workflows',
-    'invenio_knowledge',
-    'invenio_oauthclient',
-    'invenio_oauth2server',
-    'invenio_previewer',
-    # TODO 'invenio_messages',
-    'invenio_groups',
-    'invenio_access',
-    'invenio_accounts',
-    'invenio_upgrader',
     'invenio_base',
 ]
 


### PR DESCRIPTION
* Removes unnecessary packages from .travis.invenio.cfg.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>