### PR TITLE
docs: build the docs in strict mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
 
 script:
   - "check-manifest --ignore .travis-\\*-requirements.txt"
-  - "sphinx-build -qnN docs docs/_build/html"
+  - "sphinx-build -qnNW docs docs/_build/html"
   - "python setup.py test"
 
 after_success:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include invenio_base/static/img/testgif
 include pytest.ini
 include tox.ini
 recursive-include docs *.bat
+recursive-include docs *.keep
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ ultramock.activate()
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
 ]
 
@@ -320,4 +321,17 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+    'flask': ('http://flask.pocoo.org/docs/', None),
+    'werkzeug': ('http://werkzeug.pocoo.org/docs/', None)
+}
+
+# Monkeypatch sphinx for shields.io images.
+import sphinx.environment
+from docutils.utils import get_source_line
+def _warn_node(self, msg, node):
+    if not msg.startswith('nonlocal image URI'):
+        self._warnfunc(msg, '{}:{}'.format(*get_source_line(node)))
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,9 +54,3 @@ Factory
 
 .. automodule:: invenio_base.factory
    :members:
-
-Bundles
--------
-
-.. automodule:: invenio_base.bundles
-   :members:


### PR DESCRIPTION
* Monkeypatch the test that complains on nonlocal image URI.
* Sidenote: if `mock>=1.1`, `mock._is_magic` is not available but travis uses the old one