### PR TITLE
app: forced static folder fix

### DIFF
--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -185,41 +185,20 @@ def _loader(init_func, entry_points=None, modules=None):
             init_func(m)
 
 
-def base_app(import_name, env_prefix='APP', instance_path=None,
-             static_folder=None, static_url_path='/static',
-             template_folder='templates', instance_relative_config=True):
+def base_app(import_name, instance_path=None, static_folder=None,
+             static_url_path='/static', template_folder='templates',
+             instance_relative_config=True):
     """Invenio base application factory.
 
     If the instance folder does not exists, it will be created.
 
     :param import_name: The name of the application package.
     :param env_prefix: Environment variable prefix.
-    :param instance_path: Instance path for Flask application. Defaults to
-        ``<env_prefix>_INSTANCE_PATH`` or if environment variable is not set
-        ``<sys.prefix>/var/<app_name>-instance``.
-    :param static_folder: Static folder path.  Defaults to
-        ``<env_prefix>_STATIC_FOLDER`` or if environment variable is not set
-        ``<sys.prefix>/var/<app_name>-instance/static``.
+    :param instance_path: Instance path for Flask application.
+    :param static_folder: Static folder path.
     :return: Flask application instance.
     """
     configure_warnings()
-
-    # Detect instance path
-    instance_path = instance_path or \
-        os.getenv(env_prefix + '_INSTANCE_PATH') or \
-        os.path.join(sys.prefix, 'var', import_name + '-instance')
-
-    # Detect static files path
-    static_folder = static_folder or \
-        os.getenv(env_prefix + '_STATIC_FOLDER') or \
-        os.path.join(instance_path, 'static')
-
-    # Create instance path if it doesn't exists
-    try:
-        if not os.path.exists(instance_path):
-            os.makedirs(instance_path)
-    except Exception:  # pragma: no cover
-        pass
 
     # Create the Flask application instance
     app = Flask(
@@ -232,6 +211,13 @@ def base_app(import_name, env_prefix='APP', instance_path=None,
     )
     # Ensure we have Click available for Flask <1.0
     FlaskCLI(app)
+
+    # Create instance path if it doesn't exists
+    try:
+        if not os.path.exists(instance_path):
+            os.makedirs(instance_path)
+    except Exception:  # pragma: no cover
+        pass
 
     return app
 

--- a/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/{{ cookiecutter.package_name }}/config.py
+++ b/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/{{ cookiecutter.package_name }}/config.py
@@ -19,7 +19,9 @@ BASE_TEMPLATE = "invenio_theme/page.html"
 COVER_TEMPLATE = "invenio_theme/page_cover.html"
 SETTINGS_TEMPLATE = "invenio_theme/settings/content.html"
 
-SECRET_KEY = "{{cookiecutter.secret_key }}"
+# WARNING: Do not share the secret key - especially do not commit it to
+# version control.
+SECRET_KEY = "{{ cookiecutter.secret_key }}"
 
 # Theme
 THEME_SITENAME = _("{{ cookiecutter.site_name }}")

--- a/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/{{ cookiecutter.package_name }}/factory.py
+++ b/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/{{ cookiecutter.package_name }}/factory.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-"""Mysite Invenio API application."""
+"""{{ cookiecutter.site_name }} application factories."""
+
+import os
+import sys
 
 from invenio_base.app import create_app_factory
 from invenio_base.wsgi import create_wsgi_factory
@@ -12,12 +15,29 @@ env_prefix = 'APP'
 
 conf_loader = create_conf_loader(config=config, env_prefix=env_prefix)
 
+instance_path = os.getenv(env_prefix + '_INSTANCE_PATH') or \
+    os.path.join(sys.prefix, 'var', '{{ cookiecutter.package_name }}-instance')
+"""Instance path for Invenio.
+
+Defaults to ``<env_prefix>_INSTANCE_PATH`` or if environment variable is not
+set ``<sys.prefix>/var/<app_name>-instance``.
+"""
+
+static_folder = os.getenv(env_prefix + '_STATIC_FOLDER') or \
+    os.path.join(instance_path, 'static')
+"""Static folder path.
+
+Defaults to ``<env_prefix>_STATIC_FOLDER`` or if environment variable is not
+set ``<sys.prefix>/var/<app_name>-instance/static``.
+"""
+
 create_api = create_app_factory(
     '{{ cookiecutter.package_name }}',
     env_prefix=env_prefix,
     conf_loader=conf_loader,
     bp_entry_points=['invenio_base.api_blueprints'],
     ext_entry_points=['invenio_base.api_apps'],
+    instance_path=instance_path,
 )
 
 
@@ -27,5 +47,7 @@ create_app = create_app_factory(
     conf_loader=conf_loader,
     bp_entry_points=['invenio_base.blueprints'],
     ext_entry_points=['invenio_base.apps'],
-    wsgi_factory=create_wsgi_factory({'/api': create_api})
+    wsgi_factory=create_wsgi_factory({'/api': create_api}),
+    instance_path=instance_path,
+    static_folder=static_folder,
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,7 +26,6 @@
 from __future__ import absolute_import, print_function
 
 import logging
-import os
 import warnings
 from os.path import exists, join
 
@@ -180,41 +179,44 @@ def test_blueprint_loader():
 def test_base_app(tmppath):
     """Test base app creation."""
     # Test default static_url_path and CLI initialization
-    app = base_app('test', 'TEST')
+    app = base_app('test')
     assert app.name == 'test'
     assert app.cli
     assert app.static_url_path == '/static'
     assert app.instance_path != tmppath
 
     # Test specifying instance path
-    app = base_app('test', 'TEST', instance_path=tmppath)
+    app = base_app('test', instance_path=tmppath)
     assert app.instance_path == tmppath
     assert exists(app.instance_path)
-    assert app.static_folder == join(app.instance_path, 'static')
-
-    # Test specifying instance path via ENV
-    os.environ['TEST_INSTANCE_PATH'] = tmppath
-    app = base_app('test', 'TEST')
-    assert app.instance_path == tmppath
+    assert app.static_folder is None
 
     # Test automatic instance path creation
     newpath = join(tmppath, 'test')
     assert not exists(newpath)
-    app = base_app('test', 'TEST', instance_path=newpath)
+    app = base_app('test', instance_path=newpath)
     assert exists(newpath)
-    assert app.static_folder == join(newpath, 'static')
+    assert app.static_folder is None
 
     # Test static folder
     staticpath = join(tmppath, 'teststatic')
-    app = base_app('test', 'TEST', static_folder=staticpath)
+    app = base_app('test', static_folder=staticpath)
     assert app.static_folder == staticpath
+    assert app.instance_path is not None
+
+    # Test static + instance folder
+    staticpath = join(tmppath, 'teststatic')
+    app = base_app('test', instance_path=tmppath,
+                   static_folder=staticpath)
+    assert app.static_folder == staticpath
+    assert app.instance_path == tmppath
 
     # Test choice loader
     searchpath = join(tmppath, "tpls")
-    app = base_app('test', 'TEST', template_folder=searchpath)
+    app = base_app('test', template_folder=searchpath)
     assert app.jinja_loader.searchpath == [searchpath]
 
-    app = base_app('test', 'TEST')
+    app = base_app('test')
     assert app.jinja_loader.searchpath == [join(app.root_path, 'templates')]
 
 


### PR DESCRIPTION
* Fixes problem with static endpoint also being installed on the API
  Flask application. (closes #36, addresses #33)

* Moves default instance and static folder paths to cookiecutter
  template. Existing installations must update their application
  factories.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>