### PR TITLE
docs: from `startproject` to `instance create`

### DIFF
--- a/invenio_base/__init__.py
+++ b/invenio_base/__init__.py
@@ -37,14 +37,14 @@ subcommands are available:
      Command Line Interface for Invenio.
 
    Options:
-     -a, --app TEXT        The application to run
+     -a, --app TEXT        The application to run.
      --debug / --no-debug  Enable or disable debug mode.
      --help                Show this message and exit.
 
    Commands:
-     run              Runs a development server.
-     shell            Runs a shell in the app context.
-     instance create  Create a new project from template.
+     run              Run development server.
+     shell            Run shell in the app context.
+     instance create  Create a new Invenio instance from template.
 
 
 The ``run`` and ``shell`` commands only works if you have specified the
@@ -53,8 +53,8 @@ The ``run`` and ``shell`` commands only works if you have specified the
 information.
 
 
-Starting a new project
-~~~~~~~~~~~~~~~~~~~~~~
+Creating a new Invenio instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``instance create`` subcommand helps you bootstrap a minimal Invenio
 application:
 

--- a/invenio_base/cmd.py
+++ b/invenio_base/cmd.py
@@ -38,7 +38,7 @@ def instance():
 @instance.command('create')
 @click.argument('name')
 def create(name):
-    """Create a new project from template."""
+    """Create a new Invenio instance from template."""
     path = resource_filename(__name__, "cookiecutter-invenio-base")
 
     result = cookiecutter(path, no_input=True,
@@ -46,7 +46,7 @@ def create(name):
                               "site_name": name,
                               "secret_key": generate_secret_key()
                               })
-    click.secho("Created project...", fg="green")
+    click.secho("Created instance...", fg="green")
     return result
 
 

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -34,7 +34,7 @@ from invenio_base.cmd import instance
 
 
 def test_instance_create():
-    """Test startproject command."""
+    """Test ``instance create`` command."""
     runner = CliRunner()
 
     # Missing arg
@@ -47,8 +47,8 @@ def test_instance_create():
         assert result.exit_code == 0
 
 
-def test_instance_create_created_project():
-    """Test startproject command checking the result project."""
+def test_instance_create_created_instance():
+    """Test ``instance create`` command checking the resulting instance."""
     runner = CliRunner()
 
     # Missing arg


### PR DESCRIPTION
* Amends remaining "start project" occurrences by "create instance"
  terminology in the output messages and the documentation.
  (addresses #28)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>