### PR TITLE
cookiecutter: addition of missing dependencies

### DIFF
--- a/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/setup.py
+++ b/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/setup.py
@@ -33,6 +33,8 @@ setup(
     install_requires=[
         'Flask>=0.11.1',
         'invenio-assets>=1.0.0a4',
+        'invenio-base>=1.0.0a11',
+        'invenio-config>=1.0.0a1',
         'invenio-db>=1.0.0a9',
         'invenio-indexer>=1.0.0a2',
         'invenio-jsonschemas>=1.0.0a2',


### PR DESCRIPTION
* Adds missing dependencies for Invenio-Base and Invenio-Config.
  (closes #64)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>