### PR TITLE
app: debug state initialization fix

### DIFF
--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -34,6 +34,7 @@ import click
 import pkg_resources
 from flask import Flask
 from flask.cli import FlaskGroup
+from flask.helpers import get_debug_flag
 
 from .cmd import instance
 
@@ -157,7 +158,7 @@ def create_cli(create_app=None):
             info.create_app = None
             app = info.load_app()
         else:
-            app = create_app(debug=getattr(info, 'debug', False))
+            app = create_app(debug=get_debug_flag())
         return app
 
     @click.group(cls=FlaskGroup, create_app=create_cli_app)
@@ -165,7 +166,7 @@ def create_cli(create_app=None):
         """Command Line Interface for Invenio."""
         pass
 
-    # Add command for startin new Invenio instances.
+    # Add command for starting new Invenio instances.
     cli.add_command(instance)
 
     return cli


### PR DESCRIPTION
* Fixes issue with Flask not setting app.debug until after the
  application creation, causing e.g. template auto-reloading or
  Flask-DebugToolbar to not be correctly initialized.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>