### PR TITLE
cookiecutter: theme config fix and version bump

### DIFF
--- a/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/setup.py
+++ b/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/setup.py
@@ -45,6 +45,6 @@ setup(
         'invenio-records-ui>=1.0.0a4',
         'invenio-search-ui>=1.0.0a2',
         'invenio-search>=1.0.0a5',
-        'invenio-theme>=1.0.0a10',
+        'invenio-theme>=1.0.0a17',
     ],
 )

--- a/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/{{ cookiecutter.package_name }}/config.py
+++ b/invenio_base/cookiecutter-invenio-base/{{ cookiecutter.site_name }}/{{ cookiecutter.package_name }}/config.py
@@ -18,7 +18,7 @@ I18N_LANGUAGES = [
 HEADER_TEMPLATE = 'invenio_theme/header.html'
 BASE_TEMPLATE = 'invenio_theme/page.html'
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
-SETTINGS_TEMPLATE = 'invenio_theme/settings/content.html'
+SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # WARNING: Do not share the secret key - especially do not commit it to
 # version control.


### PR DESCRIPTION
* FIX Bumps minimal required version of Invenio-Theme and fixes default
  settings template name.  (closes inveniosoftware/invenio#3756)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
cc @lukasheinrich