### PR TITLE
signals: application creation signals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0a15 (released 2017-08-11)
+Version 1.0.0a16 (released 2017-08-16)
 --------------------------------------
 
 - Initial refactoring for Invenio 3 compatible packages.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ========================
- Invenio-Base v1.0.0a15
+ Invenio-Base v1.0.0a16
 ========================
 
-Invenio-Base v1.0.0a15 was released on August 11, 2017.
+Invenio-Base v1.0.0a16 was released on August 16, 2017.
 
 About
 -----
@@ -17,7 +17,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-base==1.0.0a15
+   $ pip install invenio-base==1.0.0a16
 
 Documentation
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,3 +12,9 @@ WSGI factory
 
 .. automodule:: invenio_base.wsgi
    :members:
+
+Signals
+-------
+
+.. automodule:: invenio_base.signals
+   :members:

--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -36,6 +36,8 @@ from flask import Flask
 from flask.cli import FlaskGroup
 from flask.helpers import get_debug_flag
 
+from .signals import app_created, app_loaded
+
 
 def create_app_factory(app_name, config_loader=None,
                        extension_entry_points=None, extensions=None,
@@ -97,6 +99,7 @@ def create_app_factory(app_name, config_loader=None,
     """
     def _create_app(**kwargs):
         app = base_app(app_name, **app_kwargs)
+        app_created.send(_create_app, app=app)
 
         debug = kwargs.get('debug')
         if debug is not None:
@@ -126,6 +129,8 @@ def create_app_factory(app_name, config_loader=None,
             entry_points=blueprint_entry_points,
             modules=blueprints,
         )
+
+        app_loaded.send(_create_app, app=app)
 
         # Replace WSGI application using factory if provided (e.g. to install
         # WSGI middleware).

--- a/invenio_base/signals.py
+++ b/invenio_base/signals.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+"""Signals for application creation."""
+
+from blinker import Namespace
+
+_signals = Namespace()
+
+app_created = _signals.signal('app-created')
+"""Signal sent when the base Flask application have been created.
+
+Parameters:
+- ``sender`` - the application factory function.
+- ``app`` - the Flask application instance.
+
+Example receiver:
+
+.. code-block:: python
+
+   def receiver(sender, app=None, **kwargs):
+       # ...
+"""
+
+app_loaded = _signals.signal('app-loaded')
+"""Signal sent when the Flask application have been fully loaded.
+
+Parameters:
+- ``sender`` - the application factory function.
+- ``app`` - the Flask application instance.
+
+Example receiver:
+
+.. code-block:: python
+
+   def receiver(sender, app=None, **kwargs):
+       # ...
+"""

--- a/invenio_base/version.py
+++ b/invenio_base/version.py
@@ -29,4 +29,4 @@ This file is imported by ``invenio_base.__init__``, and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a15"
+__version__ = "1.0.0a16"

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+"""Test signals."""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from invenio_base.app import create_app_factory
+from invenio_base.signals import app_created, app_loaded
+
+
+def test_create_app_factory():
+    """Test signals sending."""
+    calls = {'created': 0, 'loaded': 0}
+    create_app = create_app_factory('test')
+
+    def _receiver(name):
+        def _inner(sender, app=None):
+            calls[name] += 1
+            calls['{}_app'.format(name)] = app
+        return _inner
+
+    app_created.connect(_receiver('created'), sender=create_app, weak=False)
+    app_loaded.connect(_receiver('loaded'), sender=create_app, weak=False)
+
+    assert callable(create_app)
+
+    app = create_app()
+    assert calls['created'] == 1
+    assert calls['loaded'] == 1
+    assert calls['created_app'] is app
+    assert calls['loaded_app'] is app


### PR DESCRIPTION
The idea behind the PR is that you can hook into the application creation process. In particular if you would like to e.g. modify the Flask application object. E.g. on Zenodo we need to disable strict slashes on the URL map, which has to happen fore you start adding anything to the URL map. Hence something like this:

```python
from invenio_app.factory import create_app, create_api
from invenio_base.signals import app_created

def disable_strict_slashes(sender, app=None):
    app.url_map.strict_slashes = False

app_created.connect(disable_strict_slashes, sender=create_app)
app_created.connect(disable_strict_slashes, sender=create_api)
```