### PR TITLE
app: accept callable for blueprints

### DIFF
--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -172,15 +172,23 @@ def app_loader(app, entry_points=None, modules=None):
 def blueprint_loader(app, entry_points=None, modules=None):
     """Run default blueprint loader.
 
+    The value of any entry_point or module passed can be either an instance of
+    ``flask.Blueprint`` or a callable accepting a ``flask.Flask`` application
+    instance as a single argument and returning an instance of
+    ``flask.Blueprint``.
+
     :param entry_points: List of entry points providing to Blueprints.
     :param modules: List of Blueprints.
 
     .. versionadded: 1.0.0
     """
     url_prefixes = app.config.get('BLUEPRINTS_URL_PREFIXES', {})
-    _loader(app, lambda bp: app.register_blueprint(
-        bp, url_prefix=url_prefixes.get(bp.name)
-    ), entry_points=entry_points, modules=modules)
+
+    def loader_init_func(bp_or_func):
+        bp = bp_or_func(app) if callable(bp_or_func) else bp_or_func
+        app.register_blueprint(bp, url_prefix=url_prefixes.get(bp.name))
+
+    _loader(app, loader_init_func, entry_points=entry_points, modules=modules)
 
 
 def converter_loader(app, entry_points=None, modules=None):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -209,11 +209,17 @@ def test_app_loader():
 def test_blueprint_loader():
     """Test app loader."""
     bp = Blueprint('test', 'test')
+
+    def create_blueprint_func(app):
+        return Blueprint('test2', 'test2')
+
     app = Flask('testapp')
 
     assert len(app.blueprints) == 0
-    blueprint_loader(app, modules=[bp])
-    assert len(app.blueprints) == 1
+    blueprint_loader(app, modules=[bp, create_blueprint_func])
+    assert len(app.blueprints) == 2
+    assert 'test' in app.blueprints
+    assert 'test2' in app.blueprints
 
 
 def test_coverter_loader():


### PR DESCRIPTION
* Modifies the `invenio_base.app.blueprint_loader` to also accept a
  callable. (closes #132)