### PR TITLE
tests: fix cli test command

### DIFF
--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -294,3 +294,4 @@ def configure_warnings():
         # 'default' behavior on deprecation warnings which is not to hide
         # errors.
         warnings.simplefilter('default', DeprecationWarning)
+        warnings.simplefilter('ignore', PendingDeprecationWarning)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -367,7 +367,7 @@ def test_create_cli_with_app():
     result = runner.invoke(cli)
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ['test_cmd'])
+    result = runner.invoke(cli, ['test-cmd'])
     assert result.exit_code == 0
     assert u'{0} False\n'.format(app_name) in result.output
 
@@ -389,7 +389,7 @@ def test_create_cli_without_app():
     result = runner.invoke(cli)
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ['test_cmd'])
+    result = runner.invoke(cli, ['test-cmd'])
     assert result.exit_code != 0
     assert 'FLASK_APP' in result.output
 

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -154,6 +154,6 @@ def test_migrate_secret_key():
                 instance, ['migrate-secret-key', '--old-key',
                            'OLD_SECRET_KEY'],
                 obj=script_info)
-            assert result.exit_code == -1
+            assert result.exit_code == 1
             assert entrypoint.load.called
             assert 'Failed to initialize entry point' in result.output


### PR DESCRIPTION
* Refactors tests calling a sample cli test-cmd.

* Modifies test_migrate_secret_key() to expect error
  code 1 instead of -1.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>