### PR TITLE
wsgi: make proxy fix fully configurable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@
 Changes
 =======
 
+Version 1.2.0 (released 2019-08-28)
+
+- Adds support to trust new proxy headers through the ``PROXYFIX_CONFIG``
+  configuration variable. For more information see the
+  `full documentation <api.html#invenio_base.wsgi.wsgi_proxyfix>`_.
+
+- Deprecates the usage of ``WSGI_PROXIES`` configuration which only supports
+  ``X-Forwarded-For`` headers.
+
 Version 1.1.0 (released 2019-07-29)
 
 - Add support for allowing instance path and static folder to be callables

--- a/invenio_base/version.py
+++ b/invenio_base/version.py
@@ -14,4 +14,4 @@ This file is imported by ``invenio_base.__init__``, and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'


### PR DESCRIPTION
* The general problem solved here: whenever we need to take into
  any of the following headers set by a proxy: `X-Forwarded-For`,
  `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port`,
  or `X-Forwarded-Prefix` we can fine tune it with the new
  configuration variable (see docstring for more info).

* The concrete problem solved here: when Invenio is running
  behind a proxy which does SSL termination, the
  `X-Forwarded-Proto` header is ignored causing the Flask
  application to generate URLs with the wrong HTTP scheme.
  With this change the `x_proto` parameter can be configured
  so the header is taken into account and `url_for` generates
  the correct URLs.

  Before, having one proxy in front of the app that would send
  `X-Forwarded-Proto: https`, would make the Flask app generate
  http://hostname/some/view when calling `url_for(some.view)`,
  now setting the config `PROXYFIX_CONFIG = {x_proto: 1}` would
  correctly generate https://hostname/some/view when calling
  `url_for`.