### PR TITLE
dependencies: remove cookiecutter

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = invenio_base/cookiecutter-invenio-base/*

--- a/invenio_base/cli.py
+++ b/invenio_base/cli.py
@@ -23,22 +23,6 @@ def instance():
     """Instance commands."""
 
 
-@instance.command('create')
-@click.argument('name')
-def create(name):
-    """Create a new Invenio instance from template."""
-    warnings.warn('This command has been deprecated.')
-    click.secho(
-        'This command has been deprecated. Please use this instead:\n',
-        fg='yellow',
-    )
-    click.echo(
-        'pip install cookiecutter\n'
-        'cookiecutter '
-        'https://github.com/inveniosoftware/cookiecutter-invenio-instance'
-    )
-
-
 @instance.command('entrypoints')
 @click.option(
     '-e', '--entry-point', default=None, metavar='ENTRY_POINT',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup_requires = [
 
 install_requires = [
     'blinker>=1.4',
-    'cookiecutter>=1.2.1',
     'Flask>=0.11.1',
 ]
 

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -41,20 +41,6 @@ def force_logging():
         pass
 
 
-def test_instance_create():
-    """Test ``instance create`` command."""
-    runner = CliRunner()
-
-    # Missing arg
-    result = runner.invoke(instance, ['create'])
-    assert result.exit_code != 0
-
-    # With arg
-    with runner.isolated_filesystem():
-        result = runner.invoke(instance, ['create', 'mysite'])
-        assert result.exit_code == 0
-
-
 def test_list_entry_points():
     """Test listing of entry points."""
     mock_working_set = pkg_resources.WorkingSet(entries=[])


### PR DESCRIPTION
Changes:

* Removes installation dependency on cookiecutter
* Remove coverage file in order to omit the folder
* Remove create command: It was only launching an deprecated message. It was set up 2 years ago, I think by now the community is aware enough of cookiecutter and does not use the command anymore.