### PR TITLE
Add `gc.freeze()` call and release v1.2.17

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,18 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015-2023 CERN.
+    Copyright (C) 2015-2024 CERN.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 Changes
 =======
+
+Version 1.2.16 (released 2024-01-25)
+
+- Add configurable gc.freeze() call via ``APP_GC_FREEZE`` config variable.
+  As described in https://bugs.python.org/issue31558, this improves memory
+  usage in prefork-style runtime, like uWSGI and Celery.
 
 Version 1.2.16 (released 2023-10-31)
 

--- a/invenio_base/__init__.py
+++ b/invenio_base/__init__.py
@@ -255,7 +255,7 @@ except AttributeError:
 
     security.safe_str_cmp = hmac.compare_digest
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"
 
 __all__ = (
     "__version__",

--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -8,6 +8,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio application factory."""
+import gc
 import logging
 import os.path
 import sys
@@ -133,6 +134,9 @@ def create_app_factory(
         if wsgi_factory:
             app.wsgi_app = wsgi_factory(app, **kwargs)
 
+        # See https://bugs.python.org/issue31558 for how this helps with memory use
+        if app.config.get("APP_GC_FREEZE", False):
+            gc.freeze()
         return app
 
     return _create_app
@@ -146,6 +150,7 @@ def create_cli(create_app=None):
 
     .. versionadded: 1.0.0
     """
+
     # Flask 2.0 removed support for passing script_info argument. Below
     # function is thus
     def create_cli_app(*args):


### PR DESCRIPTION
As described in https://bugs.python.org/issue31558, ths improves memory usage in prefork-style runtime, like uWSGI and Celery.

Tested locally with 40-50% memory savings on Celery and uWSGI.