### PR TITLE
urls: implement cross-app way to generate urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 2.1.0 (released 2025-04-17)
+
+- Add invenio_url_for (and related mechanisms) to generate cross-app URLs
+
 Version 2.0.0 (released 2024-11-19)
 
 - setup: set flask,werkzeug min version

--- a/invenio_base/__init__.py
+++ b/invenio_base/__init__.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2025 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -236,6 +237,7 @@ For further details about the available options run the `help` command:
 """
 
 from .app import create_app_factory, create_cli
+from .urls.helpers import invenio_url_for
 from .wsgi import create_wsgi_factory
 
 # Monkey patch Werkzeug 2.1
@@ -256,11 +258,12 @@ except AttributeError:
 
     security.safe_str_cmp = hmac.compare_digest
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 __all__ = (
     "__version__",
     "create_app_factory",
     "create_cli",
     "create_wsgi_factory",
+    "invenio_url_for",
 )

--- a/invenio_base/urls/__init__.py
+++ b/invenio_base/urls/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 Northwestern University
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Cross-app url generation."""
+
+from .builders import (
+    InvenioAppsUrlsBuilder,
+    InvenioUrlsBuilder,
+    NoOpInvenioUrlsBuilder,
+    create_invenio_apps_urls_builder_factory,
+)
+from .helpers import invenio_url_for
+
+__all__ = (
+    "InvenioAppsUrlsBuilder",
+    "InvenioUrlsBuilder",
+    "NoOpInvenioUrlsBuilder",
+    "create_invenio_apps_urls_builder_factory",
+    "invenio_url_for",
+)

--- a/invenio_base/urls/builders.py
+++ b/invenio_base/urls/builders.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 Northwestern University.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""InvenioUrlsBuilder.
+
+This code is in support of providing `invenio_url_for`, the RDM supplement
+to Flask's `url_for` which allows any part of the application (in the broad
+sense of the term) to generate URLs even if those URLs are for views registered
+in another Flask application. Other developer niceties are included.
+"""
+
+from abc import ABC, abstractmethod
+
+from flask import Flask, current_app
+from importlib_metadata import entry_points as iter_entry_points
+from werkzeug.routing import BuildError, Map, Rule
+
+from .proxies import current_app_map_adapter, other_app_map_adapter
+
+
+class InvenioUrlsBuilder(ABC):
+    """Interface of class in charge of producing urls."""
+
+    @abstractmethod
+    def build(self, endpoint, values, method=None):
+        """Build current or other app url."""
+
+
+class NoOpInvenioUrlsBuilder(InvenioUrlsBuilder):
+    """Doesn't do anything."""
+
+    def build(self, endpoint, values, method=None):
+        """Instead of building returns empty string."""
+        return ""
+
+
+class InvenioAppsUrlsBuilder(InvenioUrlsBuilder):
+    """Builds URLs with some knowledge of Invenio (app-rdm)."""
+
+    def __init__(
+        self,
+        cfg_of_app_prefix,
+        cfg_of_other_app_prefix,
+        groups_of_other_app_entrypoints,
+    ):
+        """Constructor."""
+        self.cfg_of_app_prefix = cfg_of_app_prefix
+        self.cfg_of_other_app_prefix = cfg_of_other_app_prefix
+        self.groups_of_other_app_entrypoints = groups_of_other_app_entrypoints
+
+    def _load_blueprints(self, app_tmp):
+        """Load blueprints in temporary app `app_tmp`.
+
+        This doesn't use app.py's `blueprint_loader` to sidestep circular dependency.
+        """
+        url_prefixes = app_tmp.config.get("BLUEPRINTS_URL_PREFIXES", {})
+
+        def loader_init_func(bp_or_func):
+            bp = bp_or_func(app_tmp) if callable(bp_or_func) else bp_or_func
+            app_tmp.register_blueprint(bp, url_prefix=url_prefixes.get(bp.name))
+
+        for group in self.groups_of_other_app_entrypoints:
+            for ep in set(iter_entry_points(group=group)):
+                try:
+                    loader_init_func(ep.load())
+                except Exception:
+                    app_tmp.logger.error(f"Failed to initialize entry point: {ep}")
+                    raise
+
+    def setup(self, app, **kwargs):
+        """Sets up the object for url generation.
+
+        It does so by building an internal url_map that it will reuse.
+
+        This is called before the application is fully setup (not in an application
+        context).
+        """
+        # Create a tmp Flask app. This allows us to isolate any app-level side-effect
+        # to it and not affect the current app. It also skips some initialization
+        # since the tmp app is only needed for extraction of its final url_map.
+        app_tmp = Flask("InvenioAppsUrlsBuilder")
+
+        # The tmp Flask app needs a regular application's config and extensions
+        # to load blueprints correctly. However, `app` can't be used because of
+        # error handling registration by invenio_theme/views.py:create_blueprint
+        # at time of writing and because it's cleaner this way.
+        app_tmp.config = app.config
+        app_tmp.extensions = app.extensions
+
+        # Load blueprints
+        self._load_blueprints(app_tmp)
+
+        # End goal: copy the Rules minus the view_functions (don't need them)
+        self.url_map = Map(
+            [Rule(r.rule, endpoint=r.endpoint) for r in app_tmp.url_map.iter_rules()]
+        )
+
+    def prefix(self, site_cfg):
+        """Return site prefix."""
+        return current_app.config[site_cfg].rstrip("/")
+
+    def build(self, endpoint, values, method=None):
+        """Build full url of any registered endpoint with appropriate prefix.
+
+        This is called within an application context.
+        """
+        # 1- Try to build url from current app
+        try:
+            url_adapter = current_app_map_adapter
+            url_relative = url_adapter.build(
+                endpoint, values, method=method, force_external=False
+            )
+            return self.prefix(self.cfg_of_app_prefix) + url_relative
+        except BuildError:
+            # The endpoint may be from the complementary blueprints
+            pass
+
+        # 2- Try to build url from complementary url_map
+        url_adapter = other_app_map_adapter
+        url_relative = url_adapter.build(
+            endpoint,
+            values,
+            method=method,
+            force_external=False,
+        )
+        return self.prefix(self.cfg_of_other_app_prefix) + url_relative
+
+
+def create_invenio_apps_urls_builder_factory(
+    cfg_of_app_prefix, cfg_of_other_app_prefix, groups_of_other_app_entrypoints
+):
+    """Create the factory for invenio_urls_builder that knows about dual app setup.
+
+    This function is made with knowledge of invenio-app mechanisms as a
+    convenience, but it produces a factory that produces an implementation of
+    InvenioUrlsBuilder. This means invenio-app
+    can swap it out easily for a different URL generator - just need to
+    produce a builder that implements InvenioUrlsBuilder's interface.
+
+    :param cfg_of_site_prefix: str. config for current app prefix
+    :param cfg_of_other_site_prefix: str. config for other app prefix
+    :param groups_of_other_site_entrypoints: entrypoints groups to load
+                                             blueprints of other app
+    """
+
+    def _factory(app, **kwargs):
+        builder = InvenioAppsUrlsBuilder(
+            cfg_of_app_prefix,
+            cfg_of_other_app_prefix,
+            groups_of_other_app_entrypoints,
+        )
+        builder.setup(app, **kwargs)
+        return builder
+
+    return _factory

--- a/invenio_base/urls/helpers.py
+++ b/invenio_base/urls/helpers.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 Northwestern University.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Urls helpers.
+
+Really just there to put invenio_url_for definition in a way that circumvents
+circular import.
+"""
+
+from flask import current_app
+
+
+def invenio_url_for(
+    endpoint,
+    *,
+    # _anchor = None,  # TODO
+    _method=None,
+    **values,
+):
+    """A URL generator for the Invenio reality.
+
+    This function can build full (external) URLs for the current app and for setup
+    endpoints. For maximum flexibility it leaves most of the work to `invenio_urls`
+    and instance of `InvenioUrlsBuilder` setup and assigned at Flask app creation.
+    This solves the problem of generating URLs for a Flask app when inside
+    another Flask app.
+
+    Because of this and to simplify things, `invenio_url_for` only generates
+    external URLs (with scheme and server name configured by the instance of
+    `InvenioUrlsBuilder`). This makes its interface slightly different
+    than `url_for`'s.
+    """
+
+    return current_app._urls_builder.build(
+        endpoint,
+        values,
+        method=_method,
+        # _anchor=_anchor,  # TODO
+    )

--- a/invenio_base/urls/proxies.py
+++ b/invenio_base/urls/proxies.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 Northwestern University.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Proxies."""
+
+from flask import current_app, g
+from werkzeug.local import LocalProxy
+
+# The following 2 proxies were created to mimic how Flask caches the MapAdapter object
+# on the application or request.
+# See https://github.com/pallets/flask/blob/main/src/flask/app.py#L1085.
+# The hope is that this cuts down on cost of generating
+# each link (especially for search API responses)
+
+
+def other_bind():
+    """Cache MapAdapter for non-current app's url_map.
+
+    Usage of this proxy can only be done after `current_app._urls_builder.url_map`
+    has been set.
+    """
+    if "other_app_map_adapter" not in g:
+        g.other_app_map_adapter = current_app._urls_builder.url_map.bind("")
+    return g.other_app_map_adapter
+
+
+other_app_map_adapter = LocalProxy(other_bind)
+
+
+def current_bind():
+    """Cache MapAdapter for current app's url_map."""
+    if "current_app_map_adapter" not in g:
+        g.current_app_map_adapter = current_app.url_map.bind("")
+    return g.current_app_map_adapter
+
+
+current_app_map_adapter = LocalProxy(current_bind)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 Northwestern University.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+from unittest.mock import patch
+
+from flask import Blueprint, url_for
+from importlib_metadata import EntryPoint
+from werkzeug.routing import BuildError, Map, Rule
+
+from invenio_base import invenio_url_for
+from invenio_base.app import create_app_factory
+from invenio_base.urls.builders import (
+    InvenioUrlsBuilder,
+    create_invenio_apps_urls_builder_factory,
+)
+
+
+class UrlsBuilderForTest(InvenioUrlsBuilder):
+    """Test urls builder."""
+
+    def __init__(self):
+        """Constructor."""
+        self.url_map = Map(
+            [
+                Rule("/foo", endpoint="endpoint_foo_of_other_app"),
+            ]
+        )
+        self.url_adapter = self.url_map.bind("")
+
+    def build(self, endpoint, values, method=None):
+        """Build url for any registered blueprints."""
+        try:
+            return url_for(endpoint, **values, _method=method, _external=True)
+        except BuildError:
+            url_relative = self.url_adapter.build(
+                endpoint,
+                values,
+                method=method,
+            )
+            return "https://example.org/api" + url_relative
+
+
+def factory_for_test(app, **kwargs):
+    """Returns a test urls builder."""
+    return UrlsBuilderForTest()
+
+
+def test_generic_setup_of_invenio_url_for():
+    """This simply tests overall integration/interfaces.
+
+    The tests after this one actually test the specific implementation that will be
+    used for InvenioRDM.
+    """
+
+    def _config_loader(app, **kwargs):
+        app.config["SERVER_NAME"] = "example.org"
+        app.config["PREFERRED_URL_SCHEME"] = "https"
+
+    create_app = create_app_factory(
+        "test", urls_builder_factory=factory_for_test, config_loader=_config_loader
+    )
+    app = create_app()
+    app.add_url_rule("/foo", endpoint="endpoint_foo_of_this_app")
+
+    assert app._urls_builder
+    with app.app_context():
+        # Both current and other app URLs can be generated
+        assert "https://example.org/foo" == invenio_url_for("endpoint_foo_of_this_app")
+        assert "https://example.org/api/foo" == invenio_url_for(
+            "endpoint_foo_of_other_app"
+        )
+    # even in request context the full external URL is returned
+    with app.test_request_context():
+        assert "https://example.org/foo" == invenio_url_for("endpoint_foo_of_this_app")
+        assert "https://example.org/api/foo" == invenio_url_for(
+            "endpoint_foo_of_other_app"
+        )
+
+
+# InvenioAppsUrlsBuilder tests
+
+
+class MockEntryPoint(EntryPoint):
+    """Mocking of entrypoint."""
+
+    def load(self):
+        """Mock load entry point."""
+        if self.name == "fail":
+            raise Exception("Fail")
+        return self.name
+
+
+class MockBlueprintEntryPoint:  # EntryPoint by any other name
+    """Mocking of entrypoint for blueprints.
+
+    Not inheriting from Entrypoint because they are immutable.
+    """
+
+    def __init__(self, name, rule_endpoint_tuples):
+        """Constructor."""
+        self.name = name
+        self.rule_endpoint_tuples = rule_endpoint_tuples
+
+    def load(self):
+        """Mock load entry point."""
+        bp = Blueprint(self.name, __name__)
+        for rule, endpoint in self.rule_endpoint_tuples:
+            bp.add_url_rule(rule, endpoint=endpoint)
+        return bp
+
+
+def _mock_iter_entry_points(group=None):
+    data = {
+        "invenio_base.blueprints": [
+            MockBlueprintEntryPoint(
+                "ui_blueprint", [("/foo", "endpoint_foo_of_ui_app")]
+            ),
+        ],
+        "invenio_base.api_blueprints": [
+            MockBlueprintEntryPoint(
+                "api_blueprint", [("/foo", "endpoint_foo_of_api_app")]
+            ),
+        ],
+    }
+    names = data.keys() if group is None else [group]
+    for key in names:
+        for entry_point in data[key]:
+            yield entry_point
+
+
+def _config_loader(app, **kwargs):
+    app.config["SITE_UI_URL"] = "https://example.org"
+    app.config["SITE_API_URL"] = "https://example.org/api"
+
+
+@patch("invenio_base.app.iter_entry_points", _mock_iter_entry_points)
+@patch("invenio_base.urls.builders.iter_entry_points", _mock_iter_entry_points)
+def test_invenio_apps_urls_builder_w_ui_as_this_app():
+
+    create_app = create_app_factory(
+        "test",
+        blueprint_entry_points=["invenio_base.blueprints"],
+        config_loader=_config_loader,
+        urls_builder_factory=create_invenio_apps_urls_builder_factory(
+            "SITE_UI_URL", "SITE_API_URL", ["invenio_base.api_blueprints"]
+        ),
+    )
+    app = create_app()
+
+    with app.app_context():
+        # test for endpoint of main app
+        assert "https://example.org/foo" == invenio_url_for(
+            "ui_blueprint.endpoint_foo_of_ui_app"
+        )
+        # test for endpoint of other app
+        assert "https://example.org/api/foo" == invenio_url_for(
+            "api_blueprint.endpoint_foo_of_api_app"
+        )


### PR DESCRIPTION
As presented on telecon 2025-02-11, this introduces `invenio_url_for` a url generating helper to build urls of any app within any app. 

I'll provide a "developer commentary" to highlight the functioning, some of the decisions and places where feedback would be appreciated.

Over the next days I will post the PRs for modules that integrate this to make it even clearer how this is to be used and what benefits it gives us.

Order of merges (those with same numbers can be done in parallel, order shouldn't matter):

1- invenio-base: This one
2- invenio-app: https://github.com/inveniosoftware/invenio-app/pull/98 
3- invenio-rdm-records (preparatory PR to prevent breakage) : https://github.com/inveniosoftware/invenio-rdm-records/pull/1962
4- invenio-records-resources: https://github.com/inveniosoftware/invenio-records-resources/pull/609
4- invenio-app-rdm: https://github.com/inveniosoftware/invenio-app-rdm/pull/2988
5- invenio-communities: https://github.com/inveniosoftware/invenio-communities/pull/1276
5- invenio-rdm-records: https://github.com/inveniosoftware/invenio-rdm-records/pull/1960


Probably other modules should integrate invenio_url_for too, but this is already good and I am moving to other tasks in the short/medium-term. 
