### PR TITLE
wip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2022-2024 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -51,6 +52,7 @@ console_scripts =
     inveniomanage = invenio_base.__main__:cli
 flask.commands =
     instance = invenio_base.cli:instance
+    apply = invenio_base.cli:apply
 
 [build_sphinx]
 source-dir = docs/


### PR DESCRIPTION
that pr should enable the possibility to run something like
`invenio apply "roles create administration-moderation --description oo && roles create administration"` with one app context

i gave up to implement following:

`invenio apply "access allow administration-moderation role administration-moderation && access allow administration-access role administration"` 

 (at least for the moment):
 the problem with the `access allow` is that `allow` is a subgroup of `access` which makes it harder to find the ctx to invoke from. and i think the `resultcallback` [here](https://github.com/inveniosoftware/invenio-access/blob/9b7c8b59a36d9815aeda55fdbff730d11a8acee1/invenio_access/cli.py#L144) thing in `invenio-access` makes it also not easier.

ps.: it would be easier to refactor the `invenio-access.cli` code for me it is difficult to understand what `invenio access allow administration-moderation role administration-moderation` really does