### PR TITLE
ci: use shared pypi publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2025 CERN.
+# Copyright (C) 2025 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,28 +15,6 @@ on:
       - v*
 
 jobs:
-  Publish:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Install dependencies
-        run: |
-          pip install build
-
-      - name: Build package
-        run: |
-          python -m build
-
-      - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
+  build-n-publish:
+    uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
+    secrets: inherit


### PR DESCRIPTION
Needed to switch to later version of ubuntu for publish task and so switched it to use the common pypi-publish GA workflow.