### PR TITLE
dependency: upper pin click library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     MarkupSafe>=0.23
     Werkzeug>=3.0.0
     watchdog>2.0.0
+    click>=8.1.0,<8.2.0
     # importlib needed until Python 3.9 end of life since we're using
     # importlib.metadata features from v3.10). Version numbers are aligned with
     # Python v3.10 feature set.


### PR DESCRIPTION
- version 8.2.0 introduces changes that break the unit tests
- also version 8.2.0 drops the support for python 3.9
- for the tests to work with backwards compatibility, limit the version to 8.1.8
