### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -3,7 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
 # Copyright (C) 2022 RERO.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2025 Graz University of Technology.
 # Copyright (C) 2025 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -20,11 +20,11 @@ import click
 from flask import Flask
 from flask.cli import FlaskGroup
 from flask.helpers import get_debug_flag
-from importlib_metadata import entry_points as iter_entry_points
 
 from .signals import app_created, app_loaded
 from .urls.builders import NoOpInvenioUrlsBuilder
 from .urls.helpers import invenio_url_for
+from .utils import entry_points as iter_entry_points
 
 
 def create_app_factory(
@@ -307,6 +307,7 @@ def _loader(app, init_func, entry_points=None, modules=None):
                 except Exception:
                     app.logger.error(f"Failed to initialize entry point: {ep}")
                     raise
+
     if modules:
         for m in modules:
             try:

--- a/invenio_base/utils.py
+++ b/invenio_base/utils.py
@@ -19,7 +19,15 @@ from werkzeug.utils import import_string
 def entry_points(group):
     """Entry points."""
     if version_info < (3, 10):
-        eps = m.entry_points().get(group, [])
+        eps = m.entry_points()
+        # the only reason to add this check is to simplify the tests! the tests
+        # are implemented against python >=3.10 which uses the group keyword.
+        # since we drop python3.9 soon, this should work!
+        # in the tests there is a line which patches the return value of
+        # importlib.metadata.entry_points with a list. this works for
+        # python>=3.10 but not for 3.9
+        if isinstance(eps, dict):
+            eps = eps.get(group, [])
     else:
         eps = m.entry_points(group=group)
 

--- a/invenio_base/utils.py
+++ b/invenio_base/utils.py
@@ -2,14 +2,28 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Base utilities."""
 
+import importlib.metadata as m
+from sys import version_info
+
 from flask import current_app
 from werkzeug.utils import import_string
+
+
+def entry_points(group):
+    """Entry points."""
+    if version_info < (3, 10):
+        eps = m.entry_points().get(group, [])
+    else:
+        eps = m.entry_points(group=group)
+
+    return eps
 
 
 def obj_or_import_string(value, default=None):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2025 CERN.
 # Copyright (C) 2025 Northwestern University.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,6 @@
 from unittest.mock import patch
 
 from flask import Blueprint, url_for
-from importlib_metadata import EntryPoint
 from werkzeug.routing import BaseConverter, BuildError, Map, Rule
 
 from invenio_base import invenio_url_for


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.
