### PR TITLE
fix: python3.9 can contain duplicates

### DIFF
--- a/invenio_base/app.py
+++ b/invenio_base/app.py
@@ -280,7 +280,7 @@ def converter_loader(app, entry_points=None, modules=None):
     """
     if entry_points:
         for entry_point in entry_points:
-            for ep in set(iter_entry_points(group=entry_point)):
+            for ep in iter_entry_points(group=entry_point):
                 try:
                     app.url_map.converters[ep.name] = ep.load()
                 except Exception:
@@ -301,7 +301,7 @@ def _loader(app, init_func, entry_points=None, modules=None):
     """
     if entry_points:
         for entry_point in entry_points:
-            for ep in set(iter_entry_points(group=entry_point)):
+            for ep in iter_entry_points(group=entry_point):
                 try:
                     init_func(ep.load())
                 except Exception:

--- a/invenio_base/cli.py
+++ b/invenio_base/cli.py
@@ -70,7 +70,7 @@ def migrate_secret_key(old_key):
         raise click.ClickException("SECRET_KEY is not set in the configuration.")
 
     migrators = []
-    for ep in set(entry_points("invenio_base.secret_key")):
+    for ep in entry_points("invenio_base.secret_key"):
         try:
             migrators.append(ep.load())
         except Exception:

--- a/invenio_base/utils.py
+++ b/invenio_base/utils.py
@@ -26,8 +26,11 @@ def entry_points(group):
         # in the tests there is a line which patches the return value of
         # importlib.metadata.entry_points with a list. this works for
         # python>=3.10 but not for 3.9
+        # the return value of .get can contain duplicates. the simplest way to
+        # remove is the set() call, to still return a list, list() is called on
+        # set()
         if isinstance(eps, dict):
-            eps = eps.get(group, [])
+            eps = list(set(eps.get(group, [])))
     else:
         eps = m.entry_points(group=group)
 


### PR DESCRIPTION
* importlib.metadata.entry_points of python3.9 can contain duplicates.
  duplicates create errors on the caller side. the rest of the code
  assumes that the return value has no duplicates.
