### PR TITLE
Remove `importlib-{metadata,resources}`

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -8,7 +8,7 @@
 import os
 import sys
 
-from invenio_base.app import create_app_factory, create_cli
+from invenio_base.app import create_app_factory
 from invenio_base.wsgi import create_wsgi_factory
 
 # sphinxdoc-example-import-end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ classifiers = [
 dependencies = [
   "blinker>=1.4",
   "flask>=3.0.0",
-  "importlib-metadata>=4.4",
-  "importlib-resources>=5.0",
   "itsdangerous>=2.1.0",
   "markupsafe>=0.23",
   "watchdog>2.0.0",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@
 import importlib.metadata
 import logging
 import warnings
+from importlib.metadata import EntryPoint
 from os.path import exists, join
 from unittest.mock import patch
 
@@ -15,7 +16,6 @@ import click
 import pytest
 from click.testing import CliRunner
 from flask import Blueprint, Flask, current_app
-from importlib_metadata import EntryPoint
 from werkzeug.routing import BaseConverter
 
 from invenio_base import __version__


### PR DESCRIPTION
The minimum Python version for this package is 3.8.
`importlib.metadata` has been added in Python 3.8: https://docs.python.org/3/library/importlib.metadata.html
`importlib.resources` has been added in Python 3.7: https://docs.python.org/3/library/importlib.resources.html

Thus, I think it's safe to remove those dependencies.